### PR TITLE
Migrate MCP Server to use official GitHub server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mcp_server_github"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp_server_github"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "mcp-server-github"
 name = "GitHub MCP Server"
 description = "Model Context Protocol Server for GitHub"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
 repository = "https://github.com/LoamStudios/zed-mcp-server-github"

--- a/src/mcp_server_github.rs
+++ b/src/mcp_server_github.rs
@@ -1,34 +1,108 @@
 use serde::Deserialize;
-use std::env;
+use std::fs;
 use zed::settings::ContextServerSettings;
 use zed_extension_api::{self as zed, serde_json, Command, ContextServerId, Project, Result};
 
-const PACKAGE_NAME: &str = "@modelcontextprotocol/server-github";
-const SERVER_PATH: &str = "node_modules/@modelcontextprotocol/server-github/dist/index.js";
+const REPO_NAME: &str = "github/github-mcp-server";
+const BINARY_NAME: &str = "github-mcp-server";
 
 #[derive(Debug, Deserialize)]
 struct GitHubContextServerSettings {
     github_personal_access_token: String,
 }
 
-struct GitHubModelContextExtension;
+struct GitHubModelContextExtension {
+    cached_binary_path: Option<String>,
+}
+
+impl GitHubModelContextExtension {
+    fn context_server_binary_path(
+        &mut self,
+        _context_server_id: &ContextServerId,
+    ) -> Result<String> {
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(path.clone());
+            }
+        }
+
+        let release = zed::latest_github_release(
+            REPO_NAME,
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let (platform, arch) = zed::current_platform();
+        let asset_name = format!(
+            "{BINARY_NAME}_{os}_{arch}.{ext}",
+            arch = match arch {
+                zed::Architecture::Aarch64 => "arm64",
+                zed::Architecture::X86 => "i386",
+                zed::Architecture::X8664 => "x86_64",
+            },
+            os = match platform {
+                zed::Os::Mac => "Darwin",
+                zed::Os::Linux => "Linux",
+                zed::Os::Windows => "Windows",
+            },
+            ext = match platform {
+                zed::Os::Mac | zed::Os::Linux => "tar.gz",
+                zed::Os::Windows => "zip",
+            }
+        );
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!("{BINARY_NAME}-{}", release.version);
+        fs::create_dir_all(&version_dir)
+            .map_err(|err| format!("failed to create directory '{version_dir}': {err}"))?;
+        let binary_path = format!("{version_dir}/{BINARY_NAME}");
+
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            let file_kind = match platform {
+                zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
+                zed::Os::Windows => zed::DownloadedFileType::Zip,
+            };
+
+            zed::download_file(&asset.download_url, &version_dir, file_kind)
+                .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)?;
+
+            // Removes old versions
+            let entries =
+                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+                if entry.file_name().to_str() != Some(&version_dir) {
+                    fs::remove_dir_all(entry.path()).ok();
+                }
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
+    }
+}
 
 impl zed::Extension for GitHubModelContextExtension {
     fn new() -> Self {
-        Self
+        Self {
+            cached_binary_path: None,
+        }
     }
 
     fn context_server_command(
         &mut self,
-        _context_server_id: &ContextServerId,
+        context_server_id: &ContextServerId,
         project: &Project,
     ) -> Result<Command> {
-        let latest_version = zed::npm_package_latest_version(PACKAGE_NAME)?;
-        let version = zed::npm_package_installed_version(PACKAGE_NAME)?;
-        if version.as_deref() != Some(latest_version.as_ref()) {
-            zed::npm_install_package(PACKAGE_NAME, &latest_version)?;
-        }
-
         let settings = ContextServerSettings::for_project("mcp-server-github", project)?;
         let Some(settings) = settings.settings else {
             return Err("missing `github_personal_access_token` setting".into());
@@ -37,12 +111,8 @@ impl zed::Extension for GitHubModelContextExtension {
             serde_json::from_value(settings).map_err(|e| e.to_string())?;
 
         Ok(Command {
-            command: zed::node_binary_path()?,
-            args: vec![env::current_dir()
-                .unwrap()
-                .join(SERVER_PATH)
-                .to_string_lossy()
-                .to_string()],
+            command: self.context_server_binary_path(context_server_id)?,
+            args: vec!["stdio".to_string()],
             env: vec![(
                 "GITHUB_PERSONAL_ACCESS_TOKEN".into(),
                 settings.github_personal_access_token,


### PR DESCRIPTION
In this PR, I migrate to the official [GitHub MCP server](https://github.com/github/github-mcp-server)

No settings changes are needed for users.

At this point, I have not done any work to support the translated tool descriptions.