### PR TITLE
fix: fix name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: huacnlee/zed-extension-action@v1
         with:
-          extension-name: mcp-server-linear
+          extension-name: mcp-server-github
           # extension-path: extensions/${{ extension-name }}
           push-to: LoamStudios/zed-extensions
         env:


### PR DESCRIPTION
Missed in my edits after I copied and pasted to create the extension.