### PR TITLE
Enable setting custom GitHub Host for GitHub MCP

### DIFF
--- a/configuration/default_settings.jsonc
+++ b/configuration/default_settings.jsonc
@@ -1,4 +1,6 @@
 {
   /// Your GitHub Personal Access Token
   "github_personal_access_token": "GITHUB_PERSONAL_ACCESS_TOKEN"
+  /// Your GitHub Host URL when customized (Optional)
+  // "github_host": "https://ghe.example.com/"
 }

--- a/configuration/installation_instructions.md
+++ b/configuration/installation_instructions.md
@@ -1,1 +1,3 @@
 To use GitHub's MCP, go to your account's Developer Settings and [create a Personal Access Token](https://github.com/settings/tokens).
+
+You may setup GitHub host when using custom URL slugs. For more information, see [GitHub MCP with Enterprise Server](https://github.com/github/github-mcp-server#github-enterprise-server-and-enterprise-cloud-with-data-residency-ghecom).

--- a/src/mcp_server_github.rs
+++ b/src/mcp_server_github.rs
@@ -12,6 +12,7 @@ const BINARY_NAME: &str = "github-mcp-server";
 #[derive(Debug, Deserialize, JsonSchema)]
 struct GitHubContextServerSettings {
     github_personal_access_token: String,
+    github_host: Option<String>,
 }
 
 struct GitHubModelContextExtension {
@@ -113,13 +114,19 @@ impl zed::Extension for GitHubModelContextExtension {
         let settings: GitHubContextServerSettings =
             serde_json::from_value(settings).map_err(|e| e.to_string())?;
 
+        let mut env: Vec<(String, String)> = vec![(
+            "GITHUB_PERSONAL_ACCESS_TOKEN".into(),
+            settings.github_personal_access_token,
+        )];
+
+        if let Some(github_host) = settings.github_host.filter(|h| !h.trim().is_empty()) {
+            env.push(("GITHUB_HOST".into(), github_host));
+        }
+
         Ok(Command {
             command: self.context_server_binary_path(context_server_id)?,
             args: vec!["stdio".to_string()],
-            env: vec![(
-                "GITHUB_PERSONAL_ACCESS_TOKEN".into(),
-                settings.github_personal_access_token,
-            )],
+            env,
         })
     }
 


### PR DESCRIPTION
This pull request adds support for specifying a custom GitHub host URL, which is useful for users working with GitHub Enterprise Server or custom GitHub deployments. 
The changes update configuration options, documentation, and environment variable handling to accommodate the new `github_host` setting.

**Support for custom GitHub host:**

* Added an optional `github_host` field to the `GitHubContextServerSettings` struct in `src/mcp_server_github.rs` to allow specifying a custom GitHub URL.
* Updated the environment variable setup in the `GitHubModelContextExtension` implementation to include `GITHUB_HOST` when `github_host` is provided and non-empty.

**Configuration and documentation updates:**

* Added commented example for `github_host` in `configuration/default_settings.jsonc` to guide users on how to specify a custom GitHub host.
* Updated `configuration/installation_instructions.md` to document the new `github_host` option and provide a link to further instructions for GitHub Enterprise Server.