### PR TITLE
 add OAuth fallback authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ This extension integrates [GitHub MCP Server](https://github.com/github/github-m
 
 To install navigate to: **Zed** > **Extensions**. Or use the command palette ([macOS](https://github.com/zed-industries/zed/blob/main/assets/keymaps/default-macos.json#L581), [Linux](https://github.com/zed-industries/zed/blob/main/assets/keymaps/default-linux.json#L459)) to search `extensions`.
 
-You'll need to [create a PAT with `repo` permissions](https://github.com/settings/tokens/new?description=zed-mcp-server-github&scopes=repo).
+## Authentication
+
+### OAuth (Recommended)
+
+No configuration required. When you first use the extension, GitHub MCP Server will guide you through OAuth authentication in your browser.
+
+### Personal Access Token
+
+If you prefer to use a PAT, [create one with `repo` permissions](https://github.com/settings/tokens/new?description=zed-mcp-server-github&scopes=repo) and configure it:
 
 ```json
 "context_servers": {

--- a/configuration/default_settings.jsonc
+++ b/configuration/default_settings.jsonc
@@ -1,4 +1,5 @@
 {
-  /// Your GitHub Personal Access Token
-  "github_personal_access_token": "GITHUB_PERSONAL_ACCESS_TOKEN"
+  /// Your GitHub Personal Access Token (optional).
+  /// If not provided, OAuth authentication will be used when the server starts.
+  // "github_personal_access_token": "GITHUB_PERSONAL_ACCESS_TOKEN"
 }

--- a/configuration/installation_instructions.md
+++ b/configuration/installation_instructions.md
@@ -1,1 +1,21 @@
-To use GitHub's MCP, go to your account's Developer Settings and [create a Personal Access Token](https://github.com/settings/tokens/new?description=zed-mcp-server-github&scopes=repo).
+# GitHub MCP Server Authentication
+
+This extension supports two authentication methods:
+
+## OAuth (Recommended)
+
+No configuration required. When you first use the extension without a personal access token, GitHub MCP Server will guide you through the OAuth authentication flow in your browser.
+
+## Personal Access Token
+
+If you prefer to use a personal access token:
+
+1. Go to your account's [Developer Settings](https://github.com/settings/tokens/new?description=zed-mcp-server-github&scopes=repo)
+2. Create a Personal Access Token with `repo` scope
+3. Add it to your extension settings:
+
+```json
+{
+  "github_personal_access_token": "your_token_here"
+}
+```

--- a/src/mcp_server_github.rs
+++ b/src/mcp_server_github.rs
@@ -11,7 +11,8 @@ const BINARY_NAME: &str = "github-mcp-server";
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct GitHubContextServerSettings {
-    github_personal_access_token: String,
+    #[schemars(description = "Your GitHub Personal Access Token. If not provided, OAuth authentication will be used.")]
+    github_personal_access_token: Option<String>,
 }
 
 struct GitHubModelContextExtension {
@@ -113,19 +114,25 @@ impl zed::Extension for GitHubModelContextExtension {
         project: &Project,
     ) -> Result<Command> {
         let settings = ContextServerSettings::for_project("mcp-server-github", project)?;
-        let Some(settings) = settings.settings else {
-            return Err("missing `github_personal_access_token` setting".into());
-        };
-        let settings: GitHubContextServerSettings =
-            serde_json::from_value(settings).map_err(|e| e.to_string())?;
+        let token: Option<String> = settings
+            .settings
+            .map(|s| {
+                let settings: GitHubContextServerSettings =
+                    serde_json::from_value(s).map_err(|e| e.to_string())?;
+                Ok(settings.github_personal_access_token)
+            })
+            .transpose()?
+            .flatten();
+
+        let mut env = Vec::new();
+        if let Some(pat) = token {
+            env.push(("GITHUB_PERSONAL_ACCESS_TOKEN".into(), pat));
+        }
 
         Ok(Command {
             command: self.context_server_binary_path(context_server_id)?,
             args: vec!["stdio".to_string()],
-            env: vec![(
-                "GITHUB_PERSONAL_ACCESS_TOKEN".into(),
-                settings.github_personal_access_token,
-            )],
+            env,
         })
     }
 


### PR DESCRIPTION
"No configuration required. When you first use the extension, GitHub MCP Server will guide you through OAuth authentication in your browser."